### PR TITLE
fix: force QR block to have black text

### DIFF
--- a/htdocs/core/modules/facture/doc/pdf_swissqr.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_swissqr.modules.php
@@ -857,6 +857,7 @@ class pdf_swissqr extends ModelePDFFactures
 				// Add page for the Swiss QR-invoice
                 $pdf->AddPage();
                 $this->_pagehead($pdf, $object, 0, $outputlangs);
+                $pdf->SetTextColor(0, 0, 0);
                 $this->qrinvoice($pdf, $object, $outputlangs);
 
 				$pdf->Close();


### PR DESCRIPTION
In case of coloured watermark, this was not reset to black