### PR TITLE
fix: do not allow Dolibarr's SwitzerlandQR

### DIFF
--- a/htdocs/core/modules/facture/doc/pdf_swissqr.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_swissqr.modules.php
@@ -460,7 +460,8 @@ class pdf_swissqr extends ModelePDFFactures
 				if (! empty($conf->global->INVOICE_ADD_ZATCA_QR_CODE)) {
 					$qrcodestring = $object->buildZATCAQRString();
 				} elseif (! empty($conf->global->INVOICE_ADD_SWISS_QR_CODE)) {
-					$qrcodestring = $object->buildSwitzerlandQRString();
+					// Do not allow another QR code; this module is about having the legit one.
+					// $qrcodestring = $object->buildSwitzerlandQRString();
 				}
 				if ($qrcodestring) {
 					$qrcodecolor = array('25', '25', '25');


### PR DESCRIPTION
As this module is about having the legit, official one, make sure it's not there twice.